### PR TITLE
feat: only print ansi codes if stdout is a tty

### DIFF
--- a/main.jai
+++ b/main.jai
@@ -4,9 +4,49 @@
 #import "String";
 #import "Command_Line";
 #import "Hash_Table";
-#import "Print_Color"()( USE_ANSI_CODES_ON_WINDOWS = true );
+ansi :: #import "Print_Color"()( USE_ANSI_CODES_ON_WINDOWS = true );
 
 #import,file "module.jai";
+
+// use `with_console_color` only when stdout is tty
+#if OS == .WINDOWS
+{
+    #import "Windows";
+    isatty_stdout :: () -> bool
+    {
+        fd := GetStdHandle( STD_OUTPUT_HANDLE );
+        mode: DWORD;
+        result := GetConsoleMode( fd, *mode );
+        return result != 0;
+    }
+}
+else #if OS == .LINUX || OS == .MACOS
+{
+    #import "POSIX";
+    isatty_stdout :: () -> bool
+    {
+        return isatty( 1 ) != 0;
+    }
+}
+else
+{
+    isatty_stdout :: () -> bool
+    {
+        return false;
+    }
+}
+
+with_console_color :: ( color: ansi.Console_Color, code: Code, style: ansi.Console_Style = .NORMAL, to_standard_error := false ) #expand
+{
+    if isatty_stdout()
+    {
+        ansi.with_console_color( color, code, style, to_standard_error );
+    }
+    else
+    {
+        #insert code;
+    }
+}
 
 CLI_Arguments :: struct
 {
@@ -173,7 +213,7 @@ custom_logger :: ( message: string, data: *void, info: Log_Info )
 
     if prefix
     {
-        color: Console_Color = ifx info.common_flags == .ERROR then .HI_RED else .HI_YELLOW;
+        color: ansi.Console_Color = ifx info.common_flags == .ERROR then .HI_RED else .HI_YELLOW;
         with_console_color( color, write_string( prefix ), .BOLD );
         write_string( " " );
     }


### PR DESCRIPTION
I tried using `jai-format` with neovim (via conform.nvim) and noticed that `jai-format` currently emits ANSI color codes even when using `-silent`. This affects the output when using `-to_stdout`, causing the new buffer to include the raw ANSI codes.

This PR adds a function to detect if stdout is a TTY. If it is not a TTY, `jai-format` will no longer print ANSI codes. This fixes the issue when using `jai-format` through another program or when piping output.

I also created a small helper that wraps `Print_Color.with_console_color` to reduce verbosity while keeping the code clear.

The TTY detection uses the `Windows` and `POSIX` modules (compile time) and currently should support Windows, macOS, and Linux (Windows not tested yet :c).

Feel free to adjust the PR if you have a cleaner way to achieve the same behavior.

Other ideas:
- Add a `-no_color` flag to disable ANSI codes instead of relying on TTY detection.

Note: The binary was already linked to `libc` on Linux and macOS before this PR.

PD: I saw there was a TODO about creating a neovim plugin, so in case it’s useful, here’s a minimal example of how I configured `jai-format` with `stevearc/conform.nvim` (using lazyvim):
```lua
return {
    "stevearc/conform.nvim",
    opts = function()
        local util = require("conform.util")
        return {
            formatters_by_ft = {
                jai = { "jai-format" },
            },
            formatters = {
                ["jai-format"] = {
                    command = "jai-format",
                    args = { "-silent", "-to_file", "$FILENAME" },
                    cwd = util.root_file({ ".jai-format" }),
                    stdin = false,
                },
            },
        }
    end
}

```