### PR TITLE
fix various edge cases and platform specific issues

### DIFF
--- a/.jai-format
+++ b/.jai-format
@@ -35,6 +35,7 @@ alignment_mode                              EXACT
 
 multiline_array_literal_end_on_new_line     false 
 multiline_struct_literal_end_on_new_line    false 
+procedure_call_trailing_comma_mode          MULTILINE
 
 ignore_path   modules
 # ignore_path   test_code.jai

--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ For example:
         };
 ```
 
+- procedure_call_trailing_comma_mode: default = MULTILINE\
+    Specifies whether to add a trailing comma in procedure calls.
+
+    Allowed values are:
+    - `NEVER` - remove the trailing comma.
+    - `ALWAYS` - add the trailing comma to every nonempty call.
+    - `MULTILINE` - add the trailing comma only when the formatted call contains a line break.
+
+```
+    NEVER:             ALWAYS:              MULTILINE:
+        call(value);       call(value,);       call(
+                                                   value,
+                                               );
+```
+
 - single_statement_brace_mode: default = DONT_MODIFY\
     Specifies wheter to keep, add or remove braces to single statements in control flow expressions (`if`, `for`, `while`).
     

--- a/main.jai
+++ b/main.jai
@@ -245,7 +245,7 @@ custom_logger :: ( message: string, data: *void, info: Log_Info )
 {
     #import "Windows";
 }
-else if OS == .LINUX || OS == .MACOS
+else #if OS == .LINUX || OS == .MACOS
 {
     #import "POSIX";
 }
@@ -260,7 +260,7 @@ is_tty :: () -> bool
         result := GetConsoleMode( fd, *mode );
         return result != 0;
     }
-    else if OS == .LINUX || OS == .MACOS
+    else #if OS == .LINUX || OS == .MACOS
     {
         return isatty( 1 ) != 0;
     }
@@ -289,21 +289,22 @@ read_stdin :: ( max_bytes_to_read: int ) -> string
 
     #if OS == .WINDOWS
     {
-        stdin := GetStdHandle( STD_INPUT_HANDLE );
+        stdin_handle := GetStdHandle( STD_INPUT_HANDLE );
     }
     else
     {
-        stdin := STDIN_FILENO;
+        stdin_handle := stdin;
     }
 
     to_read := max_bytes_to_read;
     ok := true;
     total_read: int;
 
-    while ok
+    while ok && to_read > 0
     {
+        requested_bytes := to_read;
         bytes_read: int;
-        ok, bytes_read = file_read( .{ stdin }, result.data + total_read, to_read );
+        ok, bytes_read = file_read( .{ stdin_handle }, result.data + total_read, to_read );
         total_read += bytes_read;
         to_read -= bytes_read;
 
@@ -336,6 +337,8 @@ read_stdin :: ( max_bytes_to_read: int ) -> string
                 return "";
             }
         }
+
+        if bytes_read < requested_bytes then break;
     }
 
     result.count = total_read;

--- a/module.jai
+++ b/module.jai
@@ -111,7 +111,6 @@ Jai_Formatter :: struct( Parser_Visit_Type: Type = Node_Visit_Data )
     indent_string: string;
     current_line: int = -1;
     previous_line: int;
-    output_line: int;
 
     current_collumn: int;
     current_alignment: int;
@@ -933,8 +932,6 @@ print_procedure :: ( f: *Jai_Formatter, p: *Procedure )
 
 print_procedure_call :: ( f: *Jai_Formatter, p: *Procedure_Call, no_semicolon := false )
 {
-    call_start_line := f.output_line;
-
     if p.inlined
     {
         print( f, "inline " );
@@ -970,7 +967,7 @@ print_procedure_call :: ( f: *Jai_Formatter, p: *Procedure_Call, no_semicolon :=
         }
     }
 
-    multiline := f.output_line > call_start_line;
+    multiline := p.location.l0 != p.location.l1;
     has_arguments := !empty_args;
     trailing_comma := has_arguments &&
                       ( f.procedure_call_trailing_comma_mode == .ALWAYS ||
@@ -2938,11 +2935,6 @@ print :: ( f: *Jai_Formatter, format: string, args: ..Any )
 
     memcpy( f.buffer.data + f.buffer.count, to_print.data, to_print.count );
     f.buffer.count += to_print.count;
-
-    for to_print
-    {
-        if it == #char "\n" then f.output_line += 1;
-    }
 
     f.current_collumn += to_print.count;
     f.previous_print_type = .STRING;

--- a/module.jai
+++ b/module.jai
@@ -2089,54 +2089,6 @@ print_inline_assembly :: ( f: *Jai_Formatter, a: *Inline_Assembly )
     print( f, a.body );
 }
 
-Module_Parameters_Syntax :: struct
-{
-    parameter_list_count: int;
-    has_body: bool;
-}
-
-get_module_parameters_syntax :: ( f: *Jai_Formatter, d: *Directive_Module_Parameters ) -> Module_Parameters_Syntax
-{
-    result: Module_Parameters_Syntax;
-    found_directive: bool;
-    paren_depth: int;
-
-    for token: f.parser.lexer.tokens
-    {
-        if !found_directive
-        {
-            found_directive = token.kind == .DIRECTIVE &&
-                              token.string_value == "module_parameters" &&
-                              token.l0 == d.location.l0 && token.c0 == d.location.c0;
-            continue;
-        }
-
-        if paren_depth == 0
-        {
-            if token.kind == #char "("
-            {
-                result.parameter_list_count += 1;
-                paren_depth = 1;
-                continue;
-            }
-
-            result.has_body = token.kind == #char "{";
-            break;
-        }
-
-        if token.kind == #char "("
-        {
-            paren_depth += 1;
-        }
-        else if token.kind == #char ")"
-        {
-            paren_depth -= 1;
-        }
-    }
-
-    return result;
-}
-
 print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
 {
     #if T ==
@@ -2401,9 +2353,8 @@ print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
         close_paren( f, d.expression != null );
 
     case Directive_Module_Parameters;
-        syntax := get_module_parameters_syntax( f, d );
         print( f, "#module_parameters" );
-        if syntax.parameter_list_count > 0
+        if d.has_module_parameters
         {
             begin_arguments( f );
             open_paren( f );
@@ -2412,7 +2363,7 @@ print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
             end_arguments( f );
         }
 
-        if syntax.parameter_list_count > 1
+        if d.has_program_parameters
         {
             begin_arguments( f );
             open_paren( f );
@@ -2421,7 +2372,14 @@ print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
             end_arguments( f );
         }
 
-        if !syntax.has_body && !no_semicolon then semicolon( f );
+        if d.body
+        {
+            print_node( f, d.body );
+        }
+        else
+        {
+            if !no_semicolon then semicolon( f );
+        }
 
     case Directive_Placeholder;
         print( f, "#placeholder " );

--- a/module.jai
+++ b/module.jai
@@ -30,6 +30,7 @@ Formatter_Config :: struct
     struct_literal_dot_mode := Struct_Literal_Dot_Mode.FORCE;
     multiline_array_literal_end_on_new_line := false;
     multiline_struct_literal_end_on_new_line := false;
+    procedure_call_trailing_comma_mode := Procedure_Call_Trailing_Comma_Mode.MULTILINE;
 
     single_statement_brace_mode := Single_Statement_Brace_Mode.DONT_MODIFY;
     single_statement_line_mode := Single_Statement_Line_Mode.DONT_MODIFY;
@@ -81,6 +82,13 @@ Struct_Literal_Dot_Mode :: enum
     REMOVE;
 }
 
+Procedure_Call_Trailing_Comma_Mode :: enum
+{
+    NEVER;
+    ALWAYS;
+    MULTILINE;
+}
+
 Alignment_Mode :: enum
 {
     NOT_SET;
@@ -103,6 +111,7 @@ Jai_Formatter :: struct( Parser_Visit_Type: Type = Node_Visit_Data )
     indent_string: string;
     current_line: int = -1;
     previous_line: int;
+    output_line: int;
 
     current_collumn: int;
     current_alignment: int;
@@ -168,7 +177,24 @@ make_formatter :: ( config: Formatter_Config ) -> Jai_Formatter( Node_Visit_Data
 reset_formatter :: ( f: *Jai_Formatter )
 {
     reset( *f.pool );
-    f.buffer.count = 0;
+
+    pool := f.pool;
+    buffer_allocator := f.buffer_allocator;
+    buffer := f.buffer;
+    buffer.count = 0;
+    max_buffer_size := f.max_buffer_size;
+    indent_string := f.indent_string;
+    config := f.config;
+
+    f.* = .{};
+    f.pool = pool;
+    f.buffer_allocator = buffer_allocator;
+    f.buffer = buffer;
+    f.max_buffer_size = max_buffer_size;
+    f.indent_string = indent_string;
+    f.config = config;
+    f.current_line = -1;
+    f.last_indent_only_alignment_line = -1;
 }
 
 deinit_formatter :: ( f: *Jai_Formatter )
@@ -907,6 +933,8 @@ print_procedure :: ( f: *Jai_Formatter, p: *Procedure )
 
 print_procedure_call :: ( f: *Jai_Formatter, p: *Procedure_Call, no_semicolon := false )
 {
+    call_start_line := f.output_line;
+
     if p.inlined
     {
         print( f, "inline " );
@@ -942,9 +970,25 @@ print_procedure_call :: ( f: *Jai_Formatter, p: *Procedure_Call, no_semicolon :=
         }
     }
 
+    multiline := f.output_line > call_start_line;
+    has_arguments := !empty_args;
+    trailing_comma := has_arguments &&
+                      ( f.procedure_call_trailing_comma_mode == .ALWAYS ||
+                        ( f.procedure_call_trailing_comma_mode == .MULTILINE && multiline ) );
+    if trailing_comma then print( f, "," );
+
     end_arguments( f );
 
-    close_paren( f, !empty_args );
+    if multiline
+    {
+        pop_alignment( f );
+        maybe_print_new_line( f, true, should_indent = true );
+        print( f, ")" );
+    }
+    else
+    {
+        close_paren( f, !empty_args );
+    }
 
     if standalone_expression( p ) && !no_semicolon
     {
@@ -2045,6 +2089,54 @@ print_inline_assembly :: ( f: *Jai_Formatter, a: *Inline_Assembly )
     print( f, a.body );
 }
 
+Module_Parameters_Syntax :: struct
+{
+    parameter_list_count: int;
+    has_body: bool;
+}
+
+get_module_parameters_syntax :: ( f: *Jai_Formatter, d: *Directive_Module_Parameters ) -> Module_Parameters_Syntax
+{
+    result: Module_Parameters_Syntax;
+    found_directive: bool;
+    paren_depth: int;
+
+    for token: f.parser.lexer.tokens
+    {
+        if !found_directive
+        {
+            found_directive = token.kind == .DIRECTIVE &&
+                              token.string_value == "module_parameters" &&
+                              token.l0 == d.location.l0 && token.c0 == d.location.c0;
+            continue;
+        }
+
+        if paren_depth == 0
+        {
+            if token.kind == #char "("
+            {
+                result.parameter_list_count += 1;
+                paren_depth = 1;
+                continue;
+            }
+
+            result.has_body = token.kind == #char "{";
+            break;
+        }
+
+        if token.kind == #char "("
+        {
+            paren_depth += 1;
+        }
+        else if token.kind == #char ")"
+        {
+            paren_depth -= 1;
+        }
+    }
+
+    return result;
+}
+
 print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
 {
     #if T ==
@@ -2057,6 +2149,9 @@ print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
         // NOTE: strings can have % in them so this "%" makes sure that the actual string value is passed to print as one of the var args and not as the format string.
         print( f, "%", d.string_value );
         print( f, "%", d.identifier );
+        f.previous_line = f.current_line;
+        f.current_line = d.location.l1;
+        f.current_collumn = d.location.c1;
     case Directive_Import;
         print( f, "#import" );
 
@@ -2306,31 +2401,27 @@ print_directive :: ( f: *Jai_Formatter, d: *$T, no_semicolon := false )
         close_paren( f, d.expression != null );
 
     case Directive_Module_Parameters;
+        syntax := get_module_parameters_syntax( f, d );
         print( f, "#module_parameters" );
-        if d.module_parameters
+        if syntax.parameter_list_count > 0
         {
             begin_arguments( f );
             open_paren( f );
-            comma_separated_node_list( f, d.module_parameters );
+            if d.module_parameters then comma_separated_node_list( f, d.module_parameters );
             close_paren( f );
             end_arguments( f );
         }
 
-        if d.program_parameters
+        if syntax.parameter_list_count > 1
         {
-            if !d.module_parameters
-            {
-                open_paren( f, false );
-                close_paren( f, false );
-            }
             begin_arguments( f );
             open_paren( f );
-            comma_separated_node_list( f, d.program_parameters );
+            if d.program_parameters then comma_separated_node_list( f, d.program_parameters );
             close_paren( f );
             end_arguments( f );
         }
 
-        semicolon( f );
+        if !syntax.has_body && !no_semicolon then semicolon( f );
 
     case Directive_Placeholder;
         print( f, "#placeholder " );
@@ -2550,6 +2641,7 @@ standalone_expression :: ( e: *Node ) -> bool
 {
     return parent_is( e, .BLOCK ) ||
            parent_is( e, .CASE ) ||
+           parent_is( e, .DIRECTIVE_SCOPE ) ||
            parent_is( e, .IF ) ||
            parent_is( e, .FOR ) ||
            parent_is( e, .WHILE ) ||
@@ -2888,6 +2980,11 @@ print :: ( f: *Jai_Formatter, format: string, args: ..Any )
 
     memcpy( f.buffer.data + f.buffer.count, to_print.data, to_print.count );
     f.buffer.count += to_print.count;
+
+    for to_print
+    {
+        if it == #char "\n" then f.output_line += 1;
+    }
 
     f.current_collumn += to_print.count;
     f.previous_print_type = .STRING;

--- a/tests/alignment.test.jai
+++ b/tests/alignment.test.jai
@@ -62,7 +62,8 @@ test :: () {
 
     a := Struct.{1, 2,
     3, test(a,
-    b, c), 4,
+    b, c,
+    ), 4,
     5};
 
     a := int.[1, 2,
@@ -71,7 +72,8 @@ test :: () {
 
     test(a, Struct.{1, 2,
     3, 4}, b, c,
-    d, e);
+    d, e,
+    );
 }
 DONE;
 
@@ -105,7 +107,8 @@ test :: () {
 
     a := Struct.{1, 2,
         3, test(a,
-            b, c), 4,
+            b, c,
+        ), 4,
         5};
 
     a := int.[1, 2,
@@ -114,7 +117,8 @@ test :: () {
 
     test(a, Struct.{1, 2,
         3, 4}, b, c,
-        d, e);
+        d, e,
+    );
 }
 DONE;
 
@@ -148,7 +152,8 @@ test :: () {
 
     a := Struct.{1, 2,
                  3, test(a,
-                         b, c), 4,
+                         b, c,
+                 ), 4,
                  5};
 
     a := int.[1, 2,
@@ -157,7 +162,8 @@ test :: () {
 
     test(a, Struct.{1, 2,
                     3, 4}, b, c,
-         d, e);
+         d, e,
+    );
 }
 DONE;
 

--- a/tests/declarations.test.jai
+++ b/tests/declarations.test.jai
@@ -192,7 +192,8 @@ test :: () {
     proc_arg((a: int) {
         b := test();
         c, d := test1();
-    });
+    },
+    );
 }
 DONE;
 

--- a/tests/directives.test.jai
+++ b/tests/directives.test.jai
@@ -1,0 +1,53 @@
+#scope_file
+
+MODULE_PARAMETERS_WITH_BODY :: #string DONE
+#module_parameters (render_api := Render_API.OPENGL)() {
+    Render_API :: enum u32 {
+        OPENGL;
+        METAL;
+    }
+}
+DONE
+
+EMPTY_MODULE_PARAMETER_LISTS :: #string DONE
+#module_parameters()();
+DONE
+
+INSERT_RUN_AFTER_SCOPE_EXPORT :: #string DONE
+#scope_export
+
+#insert #run generate_style_builder();
+DONE
+
+#scope_export
+
+module_parameters_with_body :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    source_code = MODULE_PARAMETERS_WITH_BODY;
+    expected_output = #string DONE
+#module_parameters(render_api := Render_API.OPENGL)() {
+    Render_API :: enum u32 {
+        OPENGL;
+        METAL;
+    }
+}
+DONE;
+    return result;
+} @Test
+
+empty_module_parameter_lists :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    source_code = EMPTY_MODULE_PARAMETER_LISTS;
+    expected_output = EMPTY_MODULE_PARAMETER_LISTS;
+    return result;
+} @Test
+
+insert_run_after_scope_export :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    source_code = INSERT_RUN_AFTER_SCOPE_EXPORT;
+    expected_output = INSERT_RUN_AFTER_SCOPE_EXPORT;
+    return result;
+} @Test

--- a/tests/formatter_state.test.jai
+++ b/tests/formatter_state.test.jai
@@ -1,0 +1,47 @@
+#scope_file
+
+RESET_STATE_HEAVY :: #string OUTER
+reset_state_heavy :: () {
+    print_to_builder(
+        *builder,
+        #string INNER
+            value %
+        INNER,
+        value);
+
+    if value &&
+        other_value {
+        result := nested(first,
+            second,
+            third);
+    }
+}
+OUTER
+
+RESET_STATE_DIRECTIVES :: #string DONE
+#scope_export
+
+#insert #run generate_style_builder();
+
+#module_parameters()();
+DONE
+
+RESET_STATE_SMALL :: "small :: () { call(value); }";
+
+#scope_export
+
+formatter_state_reset :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+
+    sources: [ .. ]string;
+    array_add( *sources, RESET_STATE_HEAVY );
+    array_add( *sources, RESET_STATE_SMALL );
+    array_add( *sources, RESET_STATE_DIRECTIVES );
+
+    config.alignment_mode = .INDENT_ONLY;
+    config.procedure_call_trailing_comma_mode = .ALWAYS;
+    reuse_source_codes = sources;
+    reuse_iterations = 32;
+    return result;
+} @Test

--- a/tests/procedure_calls.test.jai
+++ b/tests/procedure_calls.test.jai
@@ -1,0 +1,115 @@
+#scope_file
+
+MULTILINE_CALLS :: #string OUTER
+format_calls :: () {
+    print_to_builder(
+        *builder,
+        "value %",
+        value,
+    );
+
+    print_to_builder(
+        *builder,
+        #string INNER
+            value %
+        INNER,
+        value,
+    );
+}
+OUTER
+
+NEVER_TRAILING_COMMA_SOURCE :: #string SOURCE
+format_calls :: () {
+    empty();
+    one(value,);
+    many(
+        first,
+        second,
+    );
+}
+SOURCE
+
+NEVER_TRAILING_COMMA_EXPECTED :: #string EXPECTED
+format_calls :: () {
+    empty();
+    one(value);
+    many(
+        first,
+        second
+    );
+}
+EXPECTED
+
+ALWAYS_TRAILING_COMMA_SOURCE :: #string SOURCE
+format_calls :: () {
+    empty();
+    one(value);
+}
+SOURCE
+
+ALWAYS_TRAILING_COMMA_EXPECTED :: #string EXPECTED
+format_calls :: () {
+    empty();
+    one(value,);
+}
+EXPECTED
+
+MULTILINE_TRAILING_COMMA_SOURCE :: #string SOURCE
+format_calls :: () {
+    one(value,);
+    many(
+        first,
+        second);
+}
+SOURCE
+
+MULTILINE_TRAILING_COMMA_EXPECTED :: #string EXPECTED
+format_calls :: () {
+    one(value);
+    many(
+        first,
+        second,
+    );
+}
+EXPECTED
+
+#scope_export
+
+multiline_call_delimiters :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    config.alignment_mode = .INDENT_ONLY;
+    source_code = MULTILINE_CALLS;
+    expected_output = MULTILINE_CALLS;
+    return result;
+} @Test
+
+never_trailing_comma :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    config.alignment_mode = .INDENT_ONLY;
+    config.procedure_call_trailing_comma_mode = .NEVER;
+    source_code = NEVER_TRAILING_COMMA_SOURCE;
+    expected_output = NEVER_TRAILING_COMMA_EXPECTED;
+    return result;
+} @Test
+
+always_trailing_comma :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    config.alignment_mode = .INDENT_ONLY;
+    config.procedure_call_trailing_comma_mode = .ALWAYS;
+    source_code = ALWAYS_TRAILING_COMMA_SOURCE;
+    expected_output = ALWAYS_TRAILING_COMMA_EXPECTED;
+    return result;
+} @Test
+
+multiline_trailing_comma :: () -> Test_Parameters
+{
+    using result: Test_Parameters;
+    config.alignment_mode = .INDENT_ONLY;
+    config.procedure_call_trailing_comma_mode = .MULTILINE;
+    source_code = MULTILINE_TRAILING_COMMA_SOURCE;
+    expected_output = MULTILINE_TRAILING_COMMA_EXPECTED;
+    return result;
+} @Test

--- a/tests/test_template.jai
+++ b/tests/test_template.jai
@@ -10,6 +10,8 @@ Test_Parameters :: struct
     source_code: string;
     expected_output: string;
     expected_result := Formatter_Status.OK;
+    reuse_source_codes: []string;
+    reuse_iterations := 1;
 }
 
 test_formatting :: ( params: Test_Parameters ) -> bool
@@ -20,8 +22,15 @@ test_formatting :: ( params: Test_Parameters ) -> bool
     config := params.config;
     // NOTE: Here strings only use \n as line endings. To use \r\n we would need to specify the ,cr modifier on #string. We don't want that to make sure that the tests can be run on any system.
     config.no_carriage_return_on_windows = true;
+
+    if params.reuse_source_codes
+    {
+        return test_formatter_reuse( config, params.reuse_source_codes, params.reuse_iterations );
+    }
+
     formatter := make_formatter( config );
     defer deinit_formatter( *formatter );
+
     status, output := format_from_string( *formatter, params.source_code );
 
     if status != params.expected_result
@@ -36,6 +45,46 @@ test_formatting :: ( params: Test_Parameters ) -> bool
         print_color( " [FAILED] - output doesn't match expected output.\n", color = .HI_RED );
         print_output_diff( output, expected_output );
         return false;
+    }
+
+    print_color( " [PASSED]\n", color = .HI_GREEN );
+    return true;
+}
+
+test_formatter_reuse :: ( config: Formatter_Config, source_codes: []string, iterations: int ) -> bool
+{
+    reused := make_formatter( config );
+    defer deinit_formatter( *reused );
+
+    for 1..iterations
+    {
+        iteration := it;
+        for source_code: source_codes
+        {
+            reused_status, reused_output := format_from_string( *reused, source_code );
+
+            fresh := make_formatter( config );
+            fresh_status, fresh_output := format_from_string( *fresh, source_code );
+
+            if reused_status != fresh_status
+            {
+                print_color( " [FAILED] - reused formatter returned '%' but a fresh formatter returned '%' at iteration %, source %.\n",
+                             reused_status, fresh_status, iteration, it_index + 1, color = .HI_RED );
+                deinit_formatter( *fresh );
+                return false;
+            }
+
+            if reused_output != fresh_output
+            {
+                print_color( " [FAILED] - reused formatter output differs at iteration %, source %.\n",
+                             iteration, it_index + 1, color = .HI_RED );
+                print_output_diff( reused_output, fresh_output );
+                deinit_formatter( *fresh );
+                return false;
+            }
+
+            deinit_formatter( *fresh );
+        }
     }
 
     print_color( " [PASSED]\n", color = .HI_GREEN );


### PR DESCRIPTION
various stuff I encountered when working on a macos laptop:
- fix failing macOS and Linux builds with static `#if` branches.
- read stdin with the correct platform handle.
- stop stdin reads at EOF or the size limit ()

stuff that I encountered using `jai-format` with zed:
- reset all temporary formatter state (the formatter would crash when being reused)
- keep the formatter buffer, allocator, and configuration after a reset

miscellaneous deficiencies I stumbled upon just in the process of working:
- update line and column state after a here-string.
- preserve empty module parameter lists: ```jai #module_parameters()(); ```
- do not add a semicolon after a module parameter body.
- keep the required semicolon after a scoped `#run`: ```jai #scope_export #insert #run generate(); ```
- add canonical procedure-call trailing-comma modes:
  - `NEVER`
  - `ALWAYS`
  - `MULTILINE`
- keep empty calls unchanged: ```jai call(); ```
- format multiline calls with a final comma and a separate `)`: ```jai call( value, ); ```
- detect formatted newlines, including newlines inside here-strings.

some new tests added:
- stress test formatter reuse
- trailing commas
- tests for the other edge cases

P.S
Yes, I know, you have to be a literal psychopath to prefer the `always` setting for dangling commas, but I still added it for completeness sake, since it is technically correct syntax.